### PR TITLE
Adapted to new Alexa languageModel schema

### DIFF
--- a/src/alexa-schema.js
+++ b/src/alexa-schema.js
@@ -319,7 +319,7 @@ class alexaSchema {
         return ({ values, name });
       });
 
-      invocationName.map((name, key) => {
+      _.map(invocationName, (name, key) => {
         let jsonModel;
         let fileName;
 


### PR DESCRIPTION
As of April 2018 we will not have the old interaction model format in the console available. If you have recently used the `voxa-cli` repo, you may have found yourself removing the `interactionModel` property and synonyms values as slots instead of being synonyms for a unique slot value. So, to take advantage of the synonyms property I've grouped them without modifying the spreadsheet structure.

Also added more allowed locales.