### PR TITLE
Allow slot filling on Dialogflow via fulfilment

### DIFF
--- a/src/DialogflowSchema.ts
+++ b/src/DialogflowSchema.ts
@@ -27,6 +27,7 @@ import * as uuid from "uuid/v5";
 import { AGENT, BUILT_IN_INTENTS } from "./DialogflowDefault";
 import { IFileContent, IIntent, Schema } from "./Schema";
 import { IVoxaSheet } from "./VoxaSheet";
+import { formattedValue } from "./connectors/utils";
 
 const NAMESPACE = "dialogflow";
 const AVAILABLE_LOCALES = [
@@ -266,7 +267,7 @@ export class DialogflowSchema extends Schema {
     locale = locale.split("-")[0];
     this.builtIntents = intentsByPlatformAndEnvironments.map((rawIntent: IIntent) => {
       let { name, events } = rawIntent;
-      const { slotsDefinition } = rawIntent;
+      const { canFulfillIntent, slotsDefinition } = rawIntent;
       name = name.replace("AMAZON.", "");
       const fallbackIntent = name === "FallbackIntent";
       const action = fallbackIntent ? "input.unknown" : name;
@@ -301,7 +302,7 @@ export class DialogflowSchema extends Schema {
         ],
         priority: 500000,
         webhookUsed: true,
-        webhookForSlotFilling: false,
+        webhookForSlotFilling: formattedValue(canFulfillIntent),
         fallbackIntent,
         events
       };

--- a/src/DialogflowSchema.ts
+++ b/src/DialogflowSchema.ts
@@ -27,7 +27,7 @@ import * as uuid from "uuid/v5";
 import { AGENT, BUILT_IN_INTENTS } from "./DialogflowDefault";
 import { IFileContent, IIntent, Schema } from "./Schema";
 import { IVoxaSheet } from "./VoxaSheet";
-import { formattedValue } from "./connectors/utils";
+import { valueFormatted } from "./connectors/utils";
 
 const NAMESPACE = "dialogflow";
 const AVAILABLE_LOCALES = [
@@ -302,7 +302,7 @@ export class DialogflowSchema extends Schema {
         ],
         priority: 500000,
         webhookUsed: true,
-        webhookForSlotFilling: formattedValue(canFulfillIntent),
+        webhookForSlotFilling: valueFormatted(canFulfillIntent),
         fallbackIntent,
         events
       };

--- a/src/DialogflowSchema.ts
+++ b/src/DialogflowSchema.ts
@@ -24,10 +24,10 @@ import * as _Promise from "bluebird";
 import * as _ from "lodash";
 import * as path from "path";
 import * as uuid from "uuid/v5";
+import { valueFormatted } from "./connectors/utils";
 import { AGENT, BUILT_IN_INTENTS } from "./DialogflowDefault";
 import { IFileContent, IIntent, Schema } from "./Schema";
 import { IVoxaSheet } from "./VoxaSheet";
-import { valueFormatted } from "./connectors/utils";
 
 const NAMESPACE = "dialogflow";
 const AVAILABLE_LOCALES = [

--- a/src/connectors/utils.ts
+++ b/src/connectors/utils.ts
@@ -50,7 +50,7 @@ export function rowFormatted(acc: any[], next: any, iindex: number, arr: any[]) 
   return acc;
 }
 
-function valueFormatted(val: any) {
+export function valueFormatted(val: any) {
   const valTemp = _.toLower(val);
 
   if (_.includes(["true", "yes"], valTemp)) {


### PR DESCRIPTION
This uses the `canFulfillIntent` field, which was previously only used by Alexa intents, to determine if Dialogflow should use the fulfilment webhook for slot filling.