### PR TITLE
Fix excel empty tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed @sys. slots on dialogflow were converted into a different type
 - Fixed issue on path option on the interaction command
 - Fixed issue with platforms undefined
+- Fixed empty columns on excel
 
 ## [2.1.2] - 2019-05-08
 

--- a/src/connectors/Excel.ts
+++ b/src/connectors/Excel.ts
@@ -99,8 +99,8 @@ export async function buildFromLocalExcel(
 function processBookData(data: string[][]) {
   // this is all because of a bug in node-xlsx where the first cell of the first tab get's a lot
   // of garbage appended to it's content
-  const titleRow = data[0];
-  const firstColumnTitle = titleRow[0];
+  const titleRow = _.get(data, "[0]", "");
+  const firstColumnTitle = _.get(titleRow, "[0]", "");
   const split = firstColumnTitle.split("\n");
   if (split.length > 1) {
     titleRow[0] = split[split.length - 1];


### PR DESCRIPTION
fix #83

If for some reason theres an empty in an Office spredsheet tab the voxa interaction command crashes
```
$ npx voxa interaction
(node:17537) UnhandledPromiseRejectionWarning: TypeError: Cannot read property '0' of undefined
    at processBookData (/home/armonge/workspace/vuiagency/alexa-cup/pet-assistant/node_modules/voxa-cli/src/connectors/Excel.ts:100:36)
    at workbook.map.book (/home/armonge/workspace/vuiagency/alexa-cup/pet-assistant/node_modules/voxa-cli/src/connectors/Excel.ts:53:11)
    at Array.map (<anonymous>)
    at readFileCreateWorkbook (/home/armonge/workspace/vuiagency/alexa-cup/pet-assistant/node_modules/voxa-cli/src/connectors/Excel.ts:48:19)
    at arrayMap (/home/armonge/workspace/vuiagency/alexa-cup/pet-assistant/node_modules/lodash/lodash.js:639:23)
    at Function.map (/home/armonge/workspace/vuiagency/alexa-cup/pet-assistant/node_modules/lodash/lodash.js:9556:14)
    at interceptor (/home/armonge/workspace/vuiagency/alexa-cup/pet-assistant/node_modules/lodash/lodash.js:16993:35)
    at Function.thru (/home/armonge/workspace/vuiagency/alexa-cup/pet-assistant/node_modules/lodash/lodash.js:8797:14)
    at /home/armonge/workspace/vuiagency/alexa-cup/pet-assistant/node_modules/lodash/lodash.js:4374:28
    at arrayReduce (/home/armonge/workspace/vuiagency/alexa-cup/pet-assistant/node_modules/lodash/lodash.js:683:21)
    at baseWrapperValue (/home/armonge/workspace/vuiagency/alexa-cup/pet-assistant/node_modules/lodash/lodash.js:4373:14)
    at LodashWrapper.wrapperValue (/home/armonge/workspace/vuiagency/alexa-cup/pet-assistant/node_modules/lodash/lodash.js:9052:14)
    at Object.<anonymous> (/home/armonge/workspace/vuiagency/alexa-cup/pet-assistant/node_modules/voxa-cli/src/connectors/Excel.ts:91:6)
    at Generator.next (<anonymous>)
    at /home/armonge/workspace/vuiagency/alexa-cup/pet-assistant/node_modules/voxa-cli/lib/src/connectors/Excel.js:7:71
    at new Promise (<anonymous>)
(node:17537) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:17537) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```