### PR TITLE
Add logs of available routes when server starts

### DIFF
--- a/templates/javascript/package.json
+++ b/templates/javascript/package.json
@@ -30,6 +30,7 @@
     "alexa-mime": "^0.0.6",
     "ask-cli": "^1.7.3",
     "chai": "^4.2.0",
+    "chalk": "^2.4.2",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^4.3.0",
     "eslint-plugin-prettier": "^3.1.0",

--- a/templates/javascript/server.js
+++ b/templates/javascript/server.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const _ = require("lodash");
+const chalk = require("chalk");
 const {
   {{#if usesAlexa}}
   alexaSkill,
@@ -63,5 +64,12 @@ if (config.server.hostSkill) {
 expressApp.use(accountLinkingRoutes);
 {{/if}}
 
-expressApp.listen(config.server.port);
+expressApp.listen(config.server.port, () => {
+  console.log("");
+  console.log(chalk.green("Listening on:"));
+  console.log("");
+  Object.keys(routes).forEach((route) => {
+    console.log(chalk.green(`localhost:${config.server.port}${route}`));
+  });
+});
 exports.expressApp = expressApp;

--- a/templates/typescript/package.json
+++ b/templates/typescript/package.json
@@ -46,6 +46,7 @@
     "alexa-mime": "^0.0.6",
     "ask-cli": "^1.7.3",
     "chai": "^4.2.0",
+    "chalk": "^2.4.2",
     {{#unless accountLinking}}
     "express": "^4.17.1",
     {{/unless}}

--- a/templates/typescript/server.ts
+++ b/templates/typescript/server.ts
@@ -1,3 +1,4 @@
+import chalk from "chalk";
 import * as express from "express";
 import * as _ from "lodash";
 import { VoxaPlatform } from "voxa";
@@ -68,4 +69,11 @@ if (config.server.hostSkill) {
 expressApp.use(accountLinkingRoutes);
 {{/if}}
 
-expressApp.listen(config.server.port);
+expressApp.listen(config.server.port, () => {
+  console.log("");
+  console.log(chalk.green("Listening on:"));
+  console.log("");
+  Object.keys(routes).forEach((route) => {
+    console.log(chalk.green(`localhost:${config.server.port}${route}`));
+  });
+});


### PR DESCRIPTION
This just add console log statements when the server starts in a project generated with the `voxa-cli`. Right now there's no clue for the developer to know if the server started or not.