### PR TITLE
Updated package.json templates

### DIFF
--- a/templates/javascript/package.json
+++ b/templates/javascript/package.json
@@ -17,7 +17,6 @@
     {{/if}}
     "lambda-log": "^2.2.0",
     "lodash": "^4.17.11",
-    "prettier": "^1.18.2",
     {{#if accountLinking}}
     "serverless-http": "^2.0.2",
     {{/if}}
@@ -43,6 +42,7 @@
     "nock": "^10.0.6",
     "nodemon": "^1.19.1",
     "nyc": "^14.1.1",
+    "prettier": "^1.18.2",
     "simple-mock": "^0.8.0"{{#if voxaCli}},
     "voxa-cli": "2.2.0"{{/if}}
   },

--- a/templates/typescript/package.json
+++ b/templates/typescript/package.json
@@ -56,6 +56,7 @@
     "nock": "^10.0.6",
     "nodemon": "^1.19.1",
     "nyc": "^14.1.1",
+    "prettier": "^1.18.2",
     "serverless": "^1.45.1",
     "serverless-plugin-typescript": "^1.1.7",
     "serverless-sentry": "^1.2.0",


### PR DESCRIPTION
Updated package.json templates:
- Javascript: move prettier to devDependencies.
- Typescript: prettier missing. Added to devDependencies.

Fixes #93 