### PR TITLE
Parse number type values in manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Parse number values (height and width) in supportedViewports for Alexa Skill Manifest
 - Update nvmrc on Javascript project to v10
 - Added nvmrc to Typescript project with v10
 - Update packages, lint and refactor
-- update documentation, fix broken links 
+- update documentation, fix broken links
 
 ## [2.2.1] - 2019-09-17
 

--- a/src/Processor.ts
+++ b/src/Processor.ts
@@ -360,9 +360,17 @@ export function publishingProcessor(voxaSheets: IVoxaSheet[], AVAILABLE_LOCALES:
           .get("key", "")
           .replace("{locale}", locale)
           .value();
-        const value = _.chain(item)
+        let value = _.chain(item)
           .get("value", "")
           .value();
+
+        const containsParseNumberKey = ["maxWidth", "minWidth", "maxHeight", "minHeight"].some(s =>
+          key.includes(s)
+        );
+
+        if (containsParseNumberKey && _.toNumber(value)) {
+          value = _.toNumber(value);
+        }
 
         const publishInfo: IPublishingInformation = { key, value, environments };
         acc.push(publishInfo);


### PR DESCRIPTION
In the Alexa skill manifest you can set the supported viewports for your skill (For regular Echo Show, Echo Spot, Echo Show 5, etc.). This is not necessary unless your skill needs support for Echo Show 5 since the aspect ratio is different than the other Echo Shows, and without specifying the viewport your APL templates will show a black space on the sides.

You can specify the viewports in your publishing information spreadsheet like this:

![image](https://user-images.githubusercontent.com/2205305/73886025-6ba6a400-482e-11ea-8e55-e4b6819de89c.png)

But the values for width and height will show up as strings in the generated json manifest by voxa-cli and when updating the manifest the ask-cli will throw an error that those values need to be numbers.

This PR fixes that, parsing those values to number if they can be parsed to number.