### PR TITLE
Interaction Model creation doesn't support child-only locales for Dialogflow

### DIFF
--- a/src/DialogflowSchema.ts
+++ b/src/DialogflowSchema.ts
@@ -108,7 +108,10 @@ export class DialogflowSchema extends Schema {
     locale = locale.toLowerCase();
     const localesNotAttachedToParentLang = ["pt-br"];
 
-    if (localesNotAttachedToParentLang.find(item => locale === item)) {
+    if (
+      this.interactionOptions.ignoreDialogflowParentLocale ||
+      localesNotAttachedToParentLang.find(item => locale === item)
+    ) {
       return locale;
     }
 

--- a/src/InteractionBuilder.ts
+++ b/src/InteractionBuilder.ts
@@ -45,6 +45,7 @@ export interface IInteractionOptions {
   dialogflowSpreadsheets: string | string[];
   assets?: string[];
   assetsPath?: string;
+  ignoreDialogflowParentLocale?: boolean;
 }
 
 export interface IDefinedInteractionOptions {
@@ -59,6 +60,7 @@ export interface IDefinedInteractionOptions {
   dialogflowSpreadsheets: string | string[];
   assets: string[];
   assetsPath: string;
+  ignoreDialogflowParentLocale: boolean;
 }
 
 export const DEFAULT_INTERACTION_OPTIONS = {
@@ -68,7 +70,8 @@ export const DEFAULT_INTERACTION_OPTIONS = {
   viewsPath: "/",
   synonymPath: "synonyms",
   assets: [],
-  assetsPath: "assets"
+  assetsPath: "assets",
+  ignoreDialogflowParentLocale: false
 };
 
 function defaultOptions(interactionOptions: IInteractionOptions): IDefinedInteractionOptions {
@@ -84,6 +87,10 @@ function defaultOptions(interactionOptions: IInteractionOptions): IDefinedIntera
     interactionOptions.assetsPath || DEFAULT_INTERACTION_OPTIONS.assetsPath;
 
   const assets: string[] = interactionOptions.assets || DEFAULT_INTERACTION_OPTIONS.assets;
+
+  const ignoreDialogflowParentLocale: boolean =
+    interactionOptions.ignoreDialogflowParentLocale ||
+    DEFAULT_INTERACTION_OPTIONS.ignoreDialogflowParentLocale;
 
   const spreadsheets: string[] = arrayify(interactionOptions.spreadsheets) as string[];
 
@@ -141,7 +148,8 @@ function defaultOptions(interactionOptions: IInteractionOptions): IDefinedIntera
     assetsPath,
     contentPath,
     platforms,
-    assets
+    assets,
+    ignoreDialogflowParentLocale
   };
 }
 


### PR DESCRIPTION
It is possible to create a Dialogflow agent that only has the specific locale, such as en-AU and not the parent locale of just `en`.    This change allows the developer to define another parameter in their project in the interaction.json that forces the Voxa-CLI to ignore the parent locale behavior and only generate the utterances and entity files for the specific locale.   